### PR TITLE
Added method to load / save from arbitrary target, not only files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub fn save<'l, P, U>(path: P, document: &U) -> io::Result<()> where P: AsRef<Pa
     save_internal(&mut file, document)
 }
 
-/// Open a document from an arbitrary source
+/// Save a document to an arbitrary source
 pub fn save_to<'l, W, U>(target: W, document: &U) -> io::Result<()> where W: Write, U: Node {
     save_internal(target, document)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,10 +35,10 @@
 //!
 //! ```
 //! # extern crate svg;
+//! use std::fs::File;
 //! use svg::node::element::path::{Command, Data};
 //! use svg::node::element::tag::Path;
 //! use svg::parser::Event;
-//! use std::fs::File;
 //! 
 //! # fn main() {
 //! let path = "image.svg";
@@ -62,7 +62,7 @@
 //! # }
 //! ```
 
-use std::io;
+use std::io::{self, Read, Write};
 use std::path::Path;
 
 pub mod node;
@@ -70,58 +70,56 @@ pub mod parser;
 
 pub use node::Node;
 pub use parser::Parser;
-use std::io::{Read, Write};
 
 /// A document.
 pub type Document = node::element::SVG;
 
-/// Open a document from a path
-pub fn open<'l, P>(path: P) -> io::Result<Parser<'l>> where P: AsRef<Path> {
+/// Open a document.
+pub fn open<'l, T>(path: T) -> io::Result<Parser<'l>> where T: AsRef<Path> {
     use std::fs::File;
     let mut file = File::open(path)?;
-    open_internal(&mut file)
+    read_internal(&mut file)
 }
 
-/// Open a document from an arbitrary source
-pub fn open_from<'l, R>(source: R) -> io::Result<Parser<'l>> where R: Read {
-    open_internal(source)
+/// Read a document.
+pub fn read<'l, T>(source: T) -> io::Result<Parser<'l>> where T: Read {
+    read_internal(source)
 }
 
-/// Save a document to a path
-pub fn save<'l, P, U>(path: P, document: &U) -> io::Result<()> where P: AsRef<Path>, U: Node{
+/// Save a document.
+pub fn save<T, U>(path: T, document: &U) -> io::Result<()> where T: AsRef<Path>, U: Node {
     use std::fs::File;
     let mut file = File::create(path)?;
-    save_internal(&mut file, document)
+    write_internal(&mut file, document)
 }
 
-/// Save a document to an arbitrary source
-pub fn save_to<'l, W, U>(target: W, document: &U) -> io::Result<()> where W: Write, U: Node {
-    save_internal(target, document)
+/// Write a document.
+pub fn write<T, U>(target: T, document: &U) -> io::Result<()> where T: Write, U: Node {
+    write_internal(target, document)
 }
 
 #[inline(always)]
-fn open_internal<'l, R>(mut source: R) -> io::Result<Parser<'l>> where R: Read {
+fn read_internal<'l, R>(mut source: R) -> io::Result<Parser<'l>> where R: Read {
     let mut content = String::new();
     source.read_to_string(&mut content)?;
     Ok(Parser::new(content))
 }
 
-/// Save a document to a path
 #[inline(always)]
-fn save_internal<W, U>(mut target: W, document: &U) -> io::Result<()> where W: Write, U: Node {
+fn write_internal<T, U>(mut target: T, document: &U) -> io::Result<()> where T: Write, U: Node {
     target.write_all(&document.to_string().into_bytes())
 }
 
 #[cfg(test)]
 mod tests {
+
+    const TEST_PATH: &'static str = "tests/fixtures/benton.svg";
+
     #[test]
     fn open() {
         use parser::Event;
-        use std::fs::File;
 
-        const TEST_PATH: &'static str = "tests/fixtures/benton.svg";
-
-        let mut parser = ::open(TEST_PATH).unwrap();
+        let mut parser = ::open(self::TEST_PATH).unwrap();
 
         macro_rules! test(
             ($matcher:pat) => (match parser.next().unwrap() {
@@ -141,7 +139,11 @@ mod tests {
         test!(Event::Tag("svg", _, _));
 
         assert!(parser.next().is_none());
+    }
 
-        let _ = ::open_from(&mut File::open(TEST_PATH).unwrap());
+    #[test]
+    fn read() {
+        use std::fs::File;
+        let _ = ::read(&mut File::open(self::TEST_PATH).unwrap());
     }
 }


### PR DESCRIPTION
Added `open_from()` and `save_to` methods to load anything that implements `std::io::Read`. Does not break existing code. Needed for streaming SVG / being generic over the input method.