### PR TITLE
Derive Debug for Command struct

### DIFF
--- a/src/node/element/path/command.rs
+++ b/src/node/element/path/command.rs
@@ -2,7 +2,7 @@ use super::Parameters;
 use super::Position;
 
 /// A command of a data attribute.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum Command {
     /// [Establish][1] a new current point.
     ///

--- a/src/node/element/path/parameters.rs
+++ b/src/node/element/path/parameters.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use super::Number;
 
 /// Parameters of a command.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Parameters(Vec<Number>);
 
 impl Deref for Parameters {


### PR DESCRIPTION
It would be useful to have `Debug` for the `Command` so that you can debug what the type of the command is. If possible, you could publish a new version, but it's not urgent.