### PR TITLE
Add `Comment` node to add comment into an SVG

### DIFF
--- a/src/node/comment.rs
+++ b/src/node/comment.rs
@@ -44,3 +44,14 @@ impl Node for Comment {
     {
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Comment;
+
+    #[test]
+    fn comment() {
+        let comment = Comment::new("a comment.");
+        assert_eq!(comment.to_string(), "<!-- a comment. -->");
+    }
+}

--- a/src/node/comment.rs
+++ b/src/node/comment.rs
@@ -1,0 +1,46 @@
+use std::fmt;
+
+use crate::node::{Node, Value};
+
+/// A comment node.
+#[derive(Clone, Debug)]
+pub struct Comment {
+    content: String,
+}
+
+impl Comment {
+    /// Create a comment.
+    #[inline]
+    pub fn new<T>(content: T) -> Self
+    where
+        T: Into<String>,
+    {
+        Self {
+            content: content.into(),
+        }
+    }
+}
+
+impl fmt::Display for Comment {
+    #[inline]
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "<!-- {} -->", self.content)
+    }
+}
+
+impl Node for Comment {
+    #[inline]
+    fn append<T>(&mut self, _: T)
+    where
+        T: Node,
+    {
+    }
+
+    #[inline]
+    fn assign<T, U>(&mut self, _: T, _: U)
+    where
+        T: Into<String>,
+        U: Into<Value>,
+    {
+    }
+}

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -3,9 +3,11 @@
 use std::collections::HashMap;
 use std::fmt;
 
+mod comment;
 mod text;
 mod value;
 
+pub use self::comment::Comment;
 pub use self::text::Text;
 pub use self::value::Value;
 


### PR DESCRIPTION
The content is enclosed with the `<!-- ` and ` -->` markups.

The use must ensure that it doesn't add the ` -->` text as part of the
comment.

It has the same interface than the Text node, e.g. it implements the
Node trait as noops.