### PR TITLE
fix parsing non-ascii tag

### DIFF
--- a/src/node/element/tag.rs
+++ b/src/node/element/tag.rs
@@ -201,5 +201,6 @@ mod tests {
         test!("foo =\"bar\"", "foo", "bar");
         test!("foo= \"bar\"", "foo", "bar");
         test!("foo\t=\n'bar'  ", "foo", "bar");
+        test!("標籤='數值'", "標籤", "數值");
     }
 }

--- a/src/parser/reader.rs
+++ b/src/parser/reader.rs
@@ -29,7 +29,9 @@ impl<'l> Reader<'l> {
         if !block(self) {
             return None;
         }
-        let content = &self.content[start..self.offset].trim();
+        let start = self.content.char_indices().nth(start).unwrap().0;
+        let offset = self.content.char_indices().nth(self.offset - 1).unwrap().0;
+        let content = &self.content[start..offset + 1].trim();
         if content.is_empty() {
             None
         } else {
@@ -261,6 +263,7 @@ mod tests {
         test!("foo='bar'");
         test!("foo = \t 'bar'");
         test!("foo= \"bar\"");
+        test!("標籤='數值'");
 
         macro_rules! test(
             ($content:expr) => ({

--- a/src/parser/reader.rs
+++ b/src/parser/reader.rs
@@ -29,9 +29,7 @@ impl<'l> Reader<'l> {
         if !block(self) {
             return None;
         }
-        let start = self.content.char_indices().nth(start).unwrap().0;
-        let offset = self.content.char_indices().nth(self.offset - 1).unwrap().0;
-        let content = &self.content[start..=offset].trim();
+        let content = &self.content[start..self.offset].trim();
         if content.is_empty() {
             None
         } else {
@@ -228,7 +226,7 @@ impl<'l> Iterator for Reader<'l> {
                 } else {
                     self.column += 1;
                 }
-                self.offset += 1;
+                self.offset += c.len_utf8();
                 Some(c)
             }
             _ => None,

--- a/src/parser/reader.rs
+++ b/src/parser/reader.rs
@@ -31,7 +31,7 @@ impl<'l> Reader<'l> {
         }
         let start = self.content.char_indices().nth(start).unwrap().0;
         let offset = self.content.char_indices().nth(self.offset - 1).unwrap().0;
-        let content = &self.content[start..offset + 1].trim();
+        let content = &self.content[start..=offset].trim();
         if content.is_empty() {
             None
         } else {


### PR DESCRIPTION
Change indexing of Reader's content to by at char boundary.
I'm not entirely sure why the offset needs to be adjusted by +/-1.
Originally I considered `self.content.chars().skip(start).take(offset).collect::<String>()`, but that creates a temporary value and it wouldn't compile, unless the function returns `Option<String>` instead of `Option<&'l str>`. Not sure is there a fix or better way.