### PR TITLE
Add debug derive on Data

### DIFF
--- a/src/node/element/path/data.rs
+++ b/src/node/element/path/data.rs
@@ -7,7 +7,7 @@ use crate::parser::{Error, Reader, Result};
 /// A [data][1] attribute.
 ///
 /// [1]: https://www.w3.org/TR/SVG/paths.html#PathData
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Data(Vec<Command>);
 
 struct Parser<'l> {


### PR DESCRIPTION
Added debug derive because there was no it in Data.

<img width="433" alt="スクリーンショット 2020-04-11 22 38 58" src="https://user-images.githubusercontent.com/30266990/79045283-49257280-7c45-11ea-8ab3-759c3021d7a7.png">

You can reproduce it by writing as follows.

```rust
use svg::node::element::path::Data;

#[derive(Debug, Clone)]
pub struct Example {
    data: Data
}
```