### PR TITLE
Add into_inner for Nodes

### DIFF
--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -123,6 +123,13 @@ macro_rules! node(
                 self.$field_name.fmt(formatter)
             }
         }
+
+        impl Into<Element> for $struct_name {
+            #[inline]
+            fn into(self) -> Element {
+                self.inner
+            }
+        }
     );
 );
 


### PR DESCRIPTION
Adds an `into_inner` for Nodes to reclaim the memory. Associated with the discussion on #32.

`get_inner` works for accessing the `Element` but my project would prefer using the element constructors and then claiming the underlying `Element`.