### PR TITLE
Derive debug on Event enum

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -21,6 +21,7 @@ pub struct Parser<'l> {
 }
 
 /// An event.
+#[derive(Debug)]
 pub enum Event<'l> {
     /// An error.
     Error(Error),


### PR DESCRIPTION
This makes it easier to debug the results of a parser.