### PR TITLE
Safe parser - alternative API with &str parameter in read()

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,7 +1,5 @@
 //! The parser.
 
-use std::borrow::Cow;
-
 use crate::node::element::tag::{Tag, Type};
 use crate::node::Attributes;
 
@@ -15,9 +13,7 @@ pub use self::reader::Reader;
 
 /// A parser.
 pub struct Parser<'l> {
-    #[allow(dead_code)]
-    content: Cow<'l, str>,
-    reader: Reader<'l>,
+    reader: Reader<'l>
 }
 
 /// An event.
@@ -48,13 +44,9 @@ macro_rules! raise(
 impl<'l> Parser<'l> {
     /// Create a parser.
     #[inline]
-    pub fn new<T>(content: T) -> Self
-    where
-        T: Into<Cow<'l, str>>,
+    pub fn new(content: &'l str) -> Self
     {
-        let content = content.into();
-        let reader = unsafe { ::std::mem::transmute(Reader::new(&*content)) };
-        Parser { content, reader }
+        Parser { reader: Reader::new(content) }
     }
 
     fn next_angle(&mut self) -> Option<Event<'l>> {


### PR DESCRIPTION
closes: #6 

The alternative API in this PR requires that the `content` passed into the top-level `read()` function is already a `&str`. Therefore the client owns the memory allocation, and this `&str` can be passed around the rest of the framework safely.

It seems to have the advantage over #39 that there's no extra copy being made in memory, and that there's again only one parameter to `read()`.

I prefer this one over #39.

