### PR TITLE
Add bounds Send, Sync to trait Node

### DIFF
--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -19,7 +19,7 @@ pub type Attributes = HashMap<String, Value>;
 pub type Children = Vec<Box<dyn Node>>;
 
 /// A node.
-pub trait Node: 'static + fmt::Debug + fmt::Display + NodeClone + NodeDefaultHash {
+pub trait Node: 'static + fmt::Debug + fmt::Display + NodeClone + NodeDefaultHash + Send + Sync {
     /// Append a child node.
     fn append<T>(&mut self, _: T)
     where


### PR DESCRIPTION
Adding Send, Sync trait bounds to Node allows using this crate in multi-threaded code. This does not appear to impact any of the existing functionality of the crate.