### PR TITLE
Add Data::add method

### DIFF
--- a/src/node/element/path/data.rs
+++ b/src/node/element/path/data.rs
@@ -26,6 +26,13 @@ impl Data {
     pub fn parse(content: &str) -> Result<Self> {
         Parser::new(content).process()
     }
+
+    /// Add a command.
+    #[inline]
+    pub fn add(mut self, command: Command) -> Self {
+        self.0.push(command);
+        self
+    }
 }
 
 macro_rules! implement {


### PR DESCRIPTION
`Data` is essentially a thin wrapper around a `Vec<Command>` with nice syntactic sugar, but there doesn't seem to be a way to pass `Command`s directly into the buffer, and sometimes the syntactic sugar isn't the easiest way to go about things. This PR adds just that.