### PR TITLE
Support using euclid::Point2D as path parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ repository = "https://github.com/bodoni/svg"
 readme = "README.md"
 categories = ["multimedia::images", "parsing", "rendering::data-formats"]
 keywords = ["vector-graphics"]
+
+[dependencies]
+euclid = { version = "0.22.0", optional = true }

--- a/src/node/element/path/euclid.rs
+++ b/src/node/element/path/euclid.rs
@@ -1,0 +1,27 @@
+use euclid::{Point2D, UnknownUnit};
+
+use super::{Number, Parameters};
+
+/// If you use custom units in euclid, implement SVGUnit for CustomUnit to
+/// enable using Point2D<N, CustomUnit> as svg Parameters.
+pub trait SVGUnit {}
+
+impl SVGUnit for UnknownUnit {}
+
+macro_rules! implement {
+    ($($primitive:ty,)*) => (
+        $(impl<U> From<Point2D<$primitive, U>> for Parameters
+            where U: SVGUnit, {
+            #[inline]
+            fn from(inner: Point2D<$primitive, U>) -> Self {
+                vec![inner.x as Number, inner.y as Number].into()
+            }
+        })*
+    );
+}
+
+implement! {
+    i8, i16, i32, i64, isize,
+    u8, u16, u32, u64, usize,
+    f32, f64,
+}

--- a/src/node/element/path/mod.rs
+++ b/src/node/element/path/mod.rs
@@ -4,6 +4,12 @@ mod command;
 mod data;
 mod parameters;
 
+#[cfg(feature = "euclid")]
+mod euclid;
+
+#[cfg(feature = "euclid")]
+pub use self::euclid::SVGUnit;
+
 pub use self::command::Command;
 pub use self::data::Data;
 pub use self::parameters::Parameters;


### PR DESCRIPTION
The euclid crate is nice for working with points in 2d so it's a natural fit for SVG but it's not possible to implement `From<Point2D<N, U>> for Parameters` in your own project because of the orphan rule so I made an optional feature to support it.

Calling .to_tuple() everywhere instead would work so maybe this is overkill, up to you.