### PR TITLE
expose content of declarations to be read while parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ mod tests {
 
         test!(Event::Instruction);
         test!(Event::Comment);
-        test!(Event::Declaration);
+        test!(Event::Declaration(_));
         test!(Event::Tag("svg", _, _));
         test!(Event::Tag("path", _, _));
         test!(Event::Tag("path", _, _));

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -28,7 +28,7 @@ pub enum Event<'l> {
     /// A comment.
     Comment,
     /// A declaration.
-    Declaration,
+    Declaration(&'l str),
     /// An instruction.
     Instruction,
 }
@@ -82,10 +82,10 @@ impl<'l> Parser<'l> {
     }
 
     fn read_declaration(&mut self) -> Option<Event<'l>> {
-        if !self.reader.consume_declaration() {
-            raise!(self, "found a malformed declaration");
+        match self.reader.capture(|reader| reader.consume_declaration()) {
+            None => raise!(self, "found a malformed declaration"),
+            Some(content) => Some(Event::Declaration(content)),
         }
-        Some(Event::Declaration)
     }
 
     fn read_instruction(&mut self) -> Option<Event<'l>> {


### PR DESCRIPTION
Allow reading the content of delcarations, like the CDATA of a style. This does not parse the CDATA, but just exposes it while parsing.

This might break some code, which expects Event::Declarations to have no parameters.