### PR TITLE
Add `Blob` node

### DIFF
--- a/src/node/blob.rs
+++ b/src/node/blob.rs
@@ -1,0 +1,55 @@
+use std::collections::hash_map::DefaultHasher;
+use std::fmt;
+use std::hash::Hash;
+
+use crate::node::{Node, Value};
+
+/// A blob node.
+#[derive(Clone, Debug)]
+pub struct Blob {
+    content: String,
+}
+
+impl Blob {
+    /// Create a node.
+    #[inline]
+    pub fn new<T>(content: T) -> Self
+    where
+        T: Into<String>,
+    {
+        Blob {
+            content: content.into(),
+        }
+    }
+}
+
+impl fmt::Display for Blob {
+    #[inline]
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        self.content.fmt(formatter)
+    }
+}
+
+impl Node for Blob {
+    #[inline]
+    fn append<T>(&mut self, _: T)
+    where
+        T: Into<Box<dyn Node>>,
+    {
+    }
+
+    #[inline]
+    fn assign<T, U>(&mut self, _: T, _: U)
+    where
+        T: Into<String>,
+        U: Into<Value>,
+    {
+    }
+}
+
+impl super::NodeDefaultHash for Blob {
+    #[inline]
+    fn default_hash(&self, state: &mut DefaultHasher) {
+        self.content.hash(state);
+    }
+}

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -4,10 +4,12 @@ use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::fmt;
 
+mod blob;
 mod comment;
 mod text;
 mod value;
 
+pub use self::blob::Blob;
 pub use self::comment::Comment;
 pub use self::text::Text;
 pub use self::value::Value;


### PR DESCRIPTION
This adds a `Blob` node, restoring the ability to insert arbitrary strings into nodes without escaping the content. It has the behaviour of the text node of previous versions.

closes #78