### PR TITLE
Make `dyn Node` more usable.

### DIFF
--- a/src/node/blob.rs
+++ b/src/node/blob.rs
@@ -30,7 +30,11 @@ impl fmt::Display for Blob {
     }
 }
 
-impl Node for Blob {}
+impl Node for Blob {
+    fn get_name(&self) -> &str {
+        "blob"
+    }
+}
 
 impl super::NodeDefaultHash for Blob {
     #[inline]

--- a/src/node/blob.rs
+++ b/src/node/blob.rs
@@ -31,7 +31,7 @@ impl fmt::Display for Blob {
 }
 
 impl Node for Blob {
-    fn get_name(&self) -> &str {
+    fn get_name(&self) -> &'static str {
         "blob"
     }
 }

--- a/src/node/comment.rs
+++ b/src/node/comment.rs
@@ -45,6 +45,10 @@ impl Node for Comment {
         U: Into<Value>,
     {
     }
+
+    fn get_name(&self) -> &str {
+        "comment"
+    }
 }
 
 impl super::NodeDefaultHash for Comment {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -65,7 +65,7 @@ pub trait Node:
     fn set_attribute(&mut self, name: String, value: Value) {}
 
     /// Get the name of the node type.
-    fn get_name(&self) -> &str;
+    fn get_name(&self) -> &'static str;
 
     /// Iterate over references to the children of this [`Node`].
     fn iter_children(&self) -> ChildrenIter {

--- a/src/node/text.rs
+++ b/src/node/text.rs
@@ -35,6 +35,10 @@ impl Node for Text {
     fn is_bare(&self) -> bool {
         true
     }
+
+    fn get_name(&self) -> &str {
+        "text-node"
+    }
 }
 
 impl super::NodeDefaultHash for Text {

--- a/src/node/value.rs
+++ b/src/node/value.rs
@@ -2,8 +2,14 @@ use std::fmt;
 use std::ops::Deref;
 
 /// A value of an attribute.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Value(String);
+
+impl PartialEq<&str> for Value {
+    fn eq(&self, other: &&str) -> bool {
+        self.0 == *other
+    }
+}
 
 impl Deref for Value {
     type Target = str;


### PR DESCRIPTION
The `Node` trait currently is the only way to interact with any element in the tree in a type-safe manner via `Box<dyn Node>`. This PR adds new behaviors to the `Node` trait and its implementation generators that allow it to:

1. Determine the kind of DOM node a `dyn Node` is, though not via the Rust type system.
2. Read and write attributes of the DOM node in a dispatch-safe manner.
3. Traverse the children of a `dyn Node` immutably or mutably.

While it would be possible to do this cleanly, I suspect it'd be difficult to do without breaking things.