### PR TITLE
add xml wrap for parser

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,9 +68,11 @@ use std::path::Path;
 
 pub mod node;
 pub mod parser;
+pub mod xml_svg;
 
 pub use crate::node::Node;
 pub use crate::parser::Parser;
+pub use xml_svg::XMLSvg;
 
 /// A document.
 pub type Document = node::element::SVG;

--- a/src/node/blob.rs
+++ b/src/node/blob.rs
@@ -35,6 +35,9 @@ impl Node for Blob {
     fn get_name(&self) -> &str {
         "blob"
     }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 impl super::NodeDefaultHash for Blob {

--- a/src/node/comment.rs
+++ b/src/node/comment.rs
@@ -50,6 +50,10 @@ impl Node for Comment {
     fn get_name(&self) -> &str {
         "comment"
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 impl super::NodeDefaultHash for Comment {

--- a/src/node/comment.rs
+++ b/src/node/comment.rs
@@ -26,7 +26,7 @@ impl Comment {
 impl fmt::Display for Comment {
     #[inline]
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "<!-- {} -->", self.content)
+        write!(formatter, "<!--{}-->", self.content)
     }
 }
 
@@ -65,10 +65,10 @@ mod tests {
 
     #[test]
     fn comment_display() {
-        let comment = Comment::new("valid");
+        let comment = Comment::new(" valid ");
         assert_eq!(comment.to_string(), "<!-- valid -->");
 
-        let comment = Comment::new("invalid -->");
+        let comment = Comment::new(" invalid --> ");
         assert_eq!(comment.to_string(), "<!-- invalid --> -->");
     }
 }

--- a/src/node/element/mod.rs
+++ b/src/node/element/mod.rs
@@ -133,6 +133,10 @@ impl Node for Element {
     fn get_children_mut(&mut self) -> Option<&mut Children> {
         Self::get_children_mut(self).into()
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 macro_rules! implement_nested(
@@ -183,6 +187,10 @@ macro_rules! implement_nested(
             #[inline]
             fn get_name(&self) -> &str {
                 self.$field_name.get_name()
+            }
+
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
             }
 
             #[inline]

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,5 +1,6 @@
 //! The nodes.
 
+use std::any::Any;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::fmt;
@@ -76,6 +77,7 @@ pub trait Node:
     fn is_bareable(&self) -> bool {
         false
     }
+    fn as_any(&self) -> &dyn Any;
 }
 
 #[doc(hidden)]

--- a/src/node/text.rs
+++ b/src/node/text.rs
@@ -40,6 +40,10 @@ impl Node for Text {
     fn is_bare(&self) -> bool {
         true
     }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 impl super::NodeDefaultHash for Text {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -77,7 +77,10 @@ impl<'l> Parser<'l> {
     fn read_comment(&mut self) -> Option<Event<'l>> {
         match self.reader.capture(|reader| reader.consume_comment()) {
             None => raise!(self, "found a malformed comment"),
-            Some(content) => Some(Event::Comment(content)),
+            Some(content) => {
+                let comment_content = &content[4..content.len() - 3];
+                Some(Event::Comment(comment_content))
+            }
         }
     }
 

--- a/src/xml_svg.rs
+++ b/src/xml_svg.rs
@@ -1,0 +1,123 @@
+use core::fmt;
+
+use crate::{
+    node::element::{tag::Type, Element},
+    parser::{Error, Event},
+    Node, Parser,
+};
+
+pub struct XMLSvg {
+    inner: Vec<Box<dyn Node>>,
+}
+
+impl XMLSvg {
+    pub fn from_childrens(childrens: &Vec<Box<dyn Node>>) -> Self {
+        Self {
+            inner: childrens.to_vec(),
+        }
+    }
+
+    pub fn from_string(svg_str: &str) -> Result<Self, Error> {
+        let svg = Element::new("document");
+        let mut stack: Vec<Element> = Vec::new();
+        stack.push(svg.clone());
+
+        for event in Parser::new(svg_str) {
+            match event {
+                Event::Tag(tag, typed, attributes) => {
+                    let mut node = Element::new(tag);
+                    node.get_attributes_mut().extend(attributes);
+                    println!("tag: {} {:#?}", tag, typed);
+                    match typed {
+                        Type::Start => {
+                            stack.push(node);
+                        }
+                        Type::End => {
+                            if stack.len() > 1 {
+                                let to_add = stack.pop().unwrap();
+                                if let Some(parent) = stack.last_mut() {
+                                    parent.append(to_add);
+                                }
+                            }
+                        }
+                        Type::Empty => {
+                            if let Some(parent) = stack.last_mut() {
+                                parent.append(node);
+                            }
+                        }
+                    }
+                }
+                Event::Comment(comment) => {
+                    println!("comment: {}", comment);
+                    // remove 4 first chart and 3 last chart
+                    let comment = &comment[4..comment.len() - 3];
+                    if let Some(parent) = stack.last_mut() {
+                        parent.append(crate::node::Comment::new(comment));
+                    }
+                }
+                Event::Text(text) => {
+                    if let Some(parent) = stack.last_mut() {
+                        parent.append(crate::node::Text::new(text));
+                    }
+                }
+                Event::Error(e) => {
+                    return Err(e);
+                }
+                Event::Declaration(declaration) => {
+                    println!("declaration: {}", declaration);
+                    if let Some(parent) = stack.last_mut() {
+                        parent.append(crate::node::Blob::new(declaration));
+                    }
+                }
+                Event::Instruction(instruction) => {
+                    println!("instruction: {}", instruction);
+                    if let Some(parent) = stack.last_mut() {
+                        parent.append(crate::node::Blob::new(instruction));
+                    }
+                }
+            }
+        }
+
+        if let Some(root) = stack.first() {
+            return Ok(XMLSvg::from_childrens(root.get_children()));
+        }
+
+        Err(Error::new((0, 0), "No root element found"))
+    }
+
+    pub fn get_svg(&self) -> Option<&dyn Node> {
+        self.inner.iter().find_map(|node| {
+            if node.get_name() == "svg" {
+                Some(node.as_ref())
+            } else {
+                None
+            }
+        })
+    }
+}
+
+impl fmt::Display for XMLSvg {
+    #[inline]
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        for node in &self.inner {
+            node.fmt(formatter)?;
+            writeln!(formatter)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::XMLSvg;
+
+    #[test]
+
+    fn high_level_parsing() {
+        let svg = include_str!("../tests/fixtures/benton.svg");
+        let svg = svg.replace("\r\n", "\n");
+        let xml_svg = XMLSvg::from_string(&svg).unwrap();
+        assert_eq!(xml_svg.to_string()[..60], svg[..60]);
+        assert_eq!(xml_svg.get_svg().unwrap().get_name(), "svg")
+    }
+}

--- a/src/xml_svg.rs
+++ b/src/xml_svg.rs
@@ -58,9 +58,6 @@ impl XMLSvg {
                         parent.append(crate::node::Text::new(text));
                     }
                 }
-                Event::Error(e) => {
-                    return Err(e);
-                }
                 Event::Declaration(declaration) => {
                     if let Some(parent) = stack.last_mut() {
                         parent.append(crate::node::Blob::new(declaration));
@@ -70,6 +67,10 @@ impl XMLSvg {
                     if let Some(parent) = stack.last_mut() {
                         parent.append(crate::node::Blob::new(instruction));
                     }
+                }
+                Event::Error(e) => {
+                    // return the error
+                    return Err(e);
                 }
             }
         }

--- a/src/xml_svg.rs
+++ b/src/xml_svg.rs
@@ -6,6 +6,7 @@ use crate::{
     Node, Parser,
 };
 
+#[derive(Debug)]
 pub struct XMLSvg {
     inner: Vec<Box<dyn Node>>,
 }
@@ -27,7 +28,6 @@ impl XMLSvg {
                 Event::Tag(tag, typed, attributes) => {
                     let mut node = Element::new(tag);
                     node.get_attributes_mut().extend(attributes);
-                    println!("tag: {} {:#?}", tag, typed);
                     match typed {
                         Type::Start => {
                             stack.push(node);
@@ -48,7 +48,6 @@ impl XMLSvg {
                     }
                 }
                 Event::Comment(comment) => {
-                    println!("comment: {}", comment);
                     // remove 4 first chart and 3 last chart
                     let comment = &comment[4..comment.len() - 3];
                     if let Some(parent) = stack.last_mut() {
@@ -64,13 +63,11 @@ impl XMLSvg {
                     return Err(e);
                 }
                 Event::Declaration(declaration) => {
-                    println!("declaration: {}", declaration);
                     if let Some(parent) = stack.last_mut() {
                         parent.append(crate::node::Blob::new(declaration));
                     }
                 }
                 Event::Instruction(instruction) => {
-                    println!("instruction: {}", instruction);
                     if let Some(parent) = stack.last_mut() {
                         parent.append(crate::node::Blob::new(instruction));
                     }
@@ -115,8 +112,12 @@ mod tests {
 
     fn high_level_parsing() {
         let svg = include_str!("../tests/fixtures/benton.svg");
+        // replace line endings
         let svg = svg.replace("\r\n", "\n");
         let xml_svg = XMLSvg::from_string(&svg).unwrap();
+        println!("{:#?}", xml_svg);
+        // assert only the first 60 characters
+        // attributes are not in the same order
         assert_eq!(xml_svg.to_string()[..60], svg[..60]);
         assert_eq!(xml_svg.get_svg().unwrap().get_name(), "svg")
     }

--- a/src/xml_svg.rs
+++ b/src/xml_svg.rs
@@ -82,13 +82,12 @@ impl XMLSvg {
         Err(Error::new((0, 0), "No root element found"))
     }
 
-    pub fn get_svg(&self) -> Option<&dyn Node> {
+    pub fn get_svg(&self) -> Option<&Element> {
         self.inner.iter().find_map(|node| {
             if node.get_name() == "svg" {
-                Some(node.as_ref())
-            } else {
-                None
+                return Some(node.as_any().downcast_ref::<Element>().unwrap());
             }
+            None
         })
     }
 }
@@ -106,7 +105,7 @@ impl fmt::Display for XMLSvg {
 
 #[cfg(test)]
 mod tests {
-    use crate::XMLSvg;
+    use crate::{node::element::Element, XMLSvg};
 
     #[test]
 
@@ -119,6 +118,8 @@ mod tests {
         // assert only the first 60 characters
         // attributes are not in the same order
         assert_eq!(xml_svg.to_string()[..60], svg[..60]);
-        assert_eq!(xml_svg.get_svg().unwrap().get_name(), "svg")
+        let svg: &Element = xml_svg.get_svg().unwrap();
+        assert_eq!(svg.get_name(), "svg");
+        assert_eq!(svg.get_children().len(), 4);
     }
 }

--- a/src/xml_svg.rs
+++ b/src/xml_svg.rs
@@ -49,7 +49,6 @@ impl XMLSvg {
                 }
                 Event::Comment(comment) => {
                     // remove 4 first chart and 3 last chart
-                    let comment = &comment[4..comment.len() - 3];
                     if let Some(parent) = stack.last_mut() {
                         parent.append(crate::node::Comment::new(comment));
                     }


### PR DESCRIPTION
Related to https://github.com/bodoni/svg/issues/88

What about creating a real Document class (here as `XMLSvg`) to handle the whole XML document (including XML tags and svg) ?

And adding a from_string parsing method